### PR TITLE
[android-security-13.0.0_r10] Update password check for WAPI

### DIFF
--- a/service/java/com/android/server/wifi/WifiConfigurationUtil.java
+++ b/service/java/com/android/server/wifi/WifiConfigurationUtil.java
@@ -467,7 +467,8 @@ public class WifiConfigurationUtil {
         return true;
     }
 
-    private static boolean validatePassword(String password, boolean isAdd, boolean isSae) {
+    private static boolean validatePassword(String password, boolean isAdd, boolean isSae,
+            boolean isWapi) {
         if (isAdd) {
             if (password == null) {
                 Log.e(TAG, "validatePassword: null string");
@@ -509,7 +510,14 @@ public class WifiConfigurationUtil {
             }
         } else {
             // HEX PSK string
-            if (password.length() != PSK_SAE_HEX_LEN) {
+            if (isWapi) {
+                // Protect system against malicious actors injecting arbitrarily large passwords.
+                if (password.length() > 100) {
+                    Log.e(TAG, "validatePassword failed: WAPI hex string too long: "
+                            + password.length());
+                    return false;
+                }
+            } else if (password.length() != PSK_SAE_HEX_LEN) {
                 Log.e(TAG, "validatePassword failed: hex string size mismatch: "
                         + password.length());
                 return false;
@@ -713,15 +721,15 @@ public class WifiConfigurationUtil {
             return false;
         }
         if (config.isSecurityType(WifiConfiguration.SECURITY_TYPE_PSK)
-                && !validatePassword(config.preSharedKey, isAdd, false)) {
+                && !validatePassword(config.preSharedKey, isAdd, false, false)) {
             return false;
         }
         if (config.isSecurityType(WifiConfiguration.SECURITY_TYPE_SAE)
-                && !validatePassword(config.preSharedKey, isAdd, true)) {
+                && !validatePassword(config.preSharedKey, isAdd, true, false)) {
             return false;
         }
         if (config.isSecurityType(WifiConfiguration.SECURITY_TYPE_WAPI_PSK)
-                && !validatePassword(config.preSharedKey, isAdd, false)) {
+                && !validatePassword(config.preSharedKey, isAdd, false, true)) {
             return false;
         }
         if (config.isSecurityType(WifiConfiguration.SECURITY_TYPE_DPP)
@@ -880,11 +888,11 @@ public class WifiConfigurationUtil {
             return false;
         }
         if (config.isSecurityType(WifiConfiguration.SECURITY_TYPE_PSK)
-                && !validatePassword(config.preSharedKey, true, false)) {
+                && !validatePassword(config.preSharedKey, true, false, false)) {
             return false;
         }
         if (config.isSecurityType(WifiConfiguration.SECURITY_TYPE_SAE)
-                && !validatePassword(config.preSharedKey, true, true)) {
+                && !validatePassword(config.preSharedKey, true, true, false)) {
             return false;
         }
         // TBD: Validate some enterprise params as well in the future here.

--- a/service/tests/wifitests/src/com/android/server/wifi/WifiConfigurationUtilTest.java
+++ b/service/tests/wifitests/src/com/android/server/wifi/WifiConfigurationUtilTest.java
@@ -466,7 +466,8 @@ public class WifiConfigurationUtilTest extends WifiBaseTest {
         assertTrue(WifiConfigurationUtil.validate(config, SUPPORTED_FEATURES_ALL,
                 WifiConfigurationUtil.VALIDATE_FOR_ADD));
 
-        config.preSharedKey = "abcd123456788990013453445345465465476546";
+        config.preSharedKey = "01234567890123456789012345678901234567890123456789012345678901234567"
+                + "890123456789012345678901234567890";
         assertFalse(WifiConfigurationUtil.validate(config, SUPPORTED_FEATURES_ALL,
                 WifiConfigurationUtil.VALIDATE_FOR_ADD));
         config.preSharedKey = "";


### PR DESCRIPTION
Do not allow arbitrarily large passwords.

Bug: 275339978

Test: compile
(cherry picked from commit 38707fb4ff1405663cc24affc95244f4cc830499) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:36deae20de1a8905e6cc72764e449b2d6e469f9e) Merged-In: I15f3aff373af56c253a50c308d886a7acf661e59 Change-Id: I15f3aff373af56c253a50c308d886a7acf661e59