### PR TITLE
bugfix: tethering didn't work unless Wi-Fi was enabled at least once

### DIFF
--- a/service/java/com/android/server/wifi/SoftApManager.java
+++ b/service/java/com/android/server/wifi/SoftApManager.java
@@ -1175,6 +1175,8 @@ public class SoftApManager implements ActiveModeManager {
                                     + ", base country in SoftApCapability = "
                                     + mCurrentSoftApCapability.getCountryCode());
                         }
+                        // no-op if the HAL is already started
+                        mWifiNative.startHal();
                         if (isBridgedMode()) {
                             boolean isFallbackToSingleAp = false;
                             final List<ClientModeManager> cmms =

--- a/service/java/com/android/server/wifi/WifiNative.java
+++ b/service/java/com/android/server/wifi/WifiNative.java
@@ -518,7 +518,7 @@ public class WifiNative {
     private HashSet<StatusListener> mStatusListeners = new HashSet<>();
 
     /** Helper method invoked to start supplicant if there were no ifaces */
-    private boolean startHal() {
+    public boolean startHal() {
         synchronized (mLock) {
             if (!mIfaceMgr.hasAnyIface()) {
                 if (mWifiVendorHal.isVendorHalSupported()) {


### PR DESCRIPTION
Persistent initialization is performed by the Wifi service when it starts Wifi HAL for the first time. Wi-Fi tethering doesn't work unless this initialization is performed.