### PR TITLE
adjust hasSendDhcpHostnameEnabledChanged() to new default value

### DIFF
--- a/service/java/com/android/server/wifi/WifiConfigurationUtil.java
+++ b/service/java/com/android/server/wifi/WifiConfigurationUtil.java
@@ -279,7 +279,7 @@ public class WifiConfigurationUtil {
     public static boolean hasSendDhcpHostnameEnabledChanged(WifiConfiguration existingConfig,
             WifiConfiguration newConfig) {
         if (existingConfig == null) {
-            return !newConfig.isSendDhcpHostnameEnabled();
+            return newConfig.isSendDhcpHostnameEnabled();
         }
         return newConfig.isSendDhcpHostnameEnabled() != existingConfig.isSendDhcpHostnameEnabled();
     }


### PR DESCRIPTION
Lack of this adjustment broke the permission check in WifiConfigManager.addOrUpdateNetworkInternal().

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4162