### PR TITLE
gmscompat: use per-network MAC randomization and enable "send DHCP hostname" option in Android Auto by default

### DIFF
--- a/framework/java/android/net/wifi/WifiConfiguration.java
+++ b/framework/java/android/net/wifi/WifiConfiguration.java
@@ -3395,6 +3395,7 @@ public class WifiConfiguration implements Parcelable {
             // Per-connection MAC randomization doesn't work with some cars, see
             // https://github.com/GrapheneOS/os-issue-tracker/issues/4139
             macRandomizationSetting = RANDOMIZATION_PERSISTENT;
+            mIsSendDhcpHostnameEnabled = true;
         }
     }
 

--- a/framework/java/android/net/wifi/WifiConfiguration.java
+++ b/framework/java/android/net/wifi/WifiConfiguration.java
@@ -3390,6 +3390,12 @@ public class WifiConfiguration implements Parcelable {
         mEncryptedPreSharedKeyIv = new byte[0];
         mIpProvisioningTimedOut = false;
         mVendorData = Collections.emptyList();
+
+        if (android.app.compat.gms.GmsCompat.isAndroidAuto()) {
+            // Per-connection MAC randomization doesn't work with some cars, see
+            // https://github.com/GrapheneOS/os-issue-tracker/issues/4139
+            macRandomizationSetting = RANDOMIZATION_PERSISTENT;
+        }
     }
 
     /**

--- a/service/java/com/android/server/wifi/WifiConfigManager.java
+++ b/service/java/com/android/server/wifi/WifiConfigManager.java
@@ -1523,12 +1523,13 @@ public class WifiConfigManager {
                 && !mWifiPermissionsUtil.checkConfigOverridePermission(uid)
                 && !(newInternalConfig.isPasspoint() && uid == newInternalConfig.creatorUid)
                 && !config.fromWifiNetworkSuggestion
+                && !mWifiPermissionsUtil.checkWifiPrivilegedAndroidAutoPermission(uid)
                 && !mWifiPermissionsUtil.isDeviceInDemoMode(mContext)
                 && !(mWifiPermissionsUtil.isAdmin(uid, packageName)
                 && uid == newInternalConfig.creatorUid)) {
             Log.e(TAG, "UID " + uid + " does not have permission to modify MAC randomization "
                     + "Settings " + config.getProfileKey() + ". Must have "
-                    + "NETWORK_SETTINGS or NETWORK_SETUP_WIZARD or be in Demo Mode "
+                    + "NETWORK_SETTINGS or NETWORK_SETUP_WIZARD or WIFI_PRIVILEGED_ANDROID_AUTO or be in Demo Mode "
                     + "or be the creator adding or updating a passpoint network "
                     + "or be an admin updating their own network.");
             return new Pair<>(
@@ -1538,10 +1539,11 @@ public class WifiConfigManager {
 
         if (WifiConfigurationUtil.hasSendDhcpHostnameEnabledChanged(existingInternalConfig,
                 newInternalConfig) && !mWifiPermissionsUtil.checkNetworkSettingsPermission(uid)
+                && !mWifiPermissionsUtil.checkWifiPrivilegedAndroidAutoPermission(uid)
                 && !mWifiPermissionsUtil.checkNetworkSetupWizardPermission(uid)) {
             Log.e(TAG, "UID " + uid + " does not have permission to modify send DHCP hostname "
                     + "setting " + config.getProfileKey() + ". Must have "
-                    + "NETWORK_SETTINGS or NETWORK_SETUP_WIZARD.");
+                    + "NETWORK_SETTINGS or NETWORK_SETUP_WIZARD or WIFI_PRIVILEGED_ANDROID_AUTO.");
             return new Pair<>(
                     new NetworkUpdateResult(WifiConfiguration.INVALID_NETWORK_ID),
                     existingInternalConfig);

--- a/service/java/com/android/server/wifi/util/WifiPermissionsUtil.java
+++ b/service/java/com/android/server/wifi/util/WifiPermissionsUtil.java
@@ -833,6 +833,12 @@ public class WifiPermissionsUtil {
                 == PackageManager.PERMISSION_GRANTED;
     }
 
+    public boolean checkWifiPrivilegedAndroidAutoPermission(int uid) {
+        return mWifiPermissionsWrapper.getUidPermission(
+                android.Manifest.permission.WIFI_PRIVILEGED_ANDROID_AUTO, uid)
+                == PackageManager.PERMISSION_GRANTED;
+    }
+
     /**
      * Returns true if the |uid| holds RADIO_SCAN_WITHOUT_LOCATION permission.
      */


### PR DESCRIPTION
Depends on https://github.com/GrapheneOS/platform_frameworks_base/pull/40

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4139