### PR TITLE
fix bug causing INTERACT_ACROSS_USERS permission to be needed for Wi-Fi scanning in secondary users

### DIFF
--- a/framework/api/current.txt
+++ b/framework/api/current.txt
@@ -175,6 +175,7 @@ package android.net.wifi {
     method @Deprecated public void writeToParcel(android.os.Parcel, int);
     field @Deprecated public String BSSID;
     field @Deprecated public String FQDN;
+    field @Deprecated public static final int RANDOMIZATION_ALWAYS = 100; // 0x64
     field @Deprecated public static final int RANDOMIZATION_AUTO = 3; // 0x3
     field @Deprecated public static final int RANDOMIZATION_NONE = 0; // 0x0
     field @Deprecated public static final int RANDOMIZATION_NON_PERSISTENT = 2; // 0x2

--- a/framework/java/android/net/wifi/WifiConfiguration.java
+++ b/framework/java/android/net/wifi/WifiConfiguration.java
@@ -1865,7 +1865,8 @@ public class WifiConfiguration implements Parcelable {
             RANDOMIZATION_NONE,
             RANDOMIZATION_PERSISTENT,
             RANDOMIZATION_NON_PERSISTENT,
-            RANDOMIZATION_AUTO})
+            RANDOMIZATION_AUTO,
+            RANDOMIZATION_ALWAYS})
     public @interface MacRandomizationSetting {}
 
     /**
@@ -1890,15 +1891,21 @@ public class WifiConfiguration implements Parcelable {
     public static final int RANDOMIZATION_AUTO = 3;
 
     /**
+     * Generate a randomize MAC always
+     */
+    public static final int RANDOMIZATION_ALWAYS = 100;
+
+    /**
      * Level of MAC randomization for this network.
      * One of {@link #RANDOMIZATION_NONE}, {@link #RANDOMIZATION_AUTO},
      * {@link #RANDOMIZATION_PERSISTENT} or {@link #RANDOMIZATION_NON_PERSISTENT}.
-     * By default this field is set to {@link #RANDOMIZATION_AUTO}.
+     * {@link #RANDOMIZATION_PERSISTENT} or {@link #RANDOMIZATION_NON_PERSISTENT} or RANDOMIZATION_ALWAYS.
+     * By default this field is set to RANDOMIZATION_ALWAYS in GrapheneOS.
      * @hide
      */
     @SystemApi
     @MacRandomizationSetting
-    public int macRandomizationSetting = RANDOMIZATION_AUTO;
+    public int macRandomizationSetting = RANDOMIZATION_ALWAYS;
 
     /**
      * Set the MAC randomization setting for this network.

--- a/framework/java/android/net/wifi/WifiConfiguration.java
+++ b/framework/java/android/net/wifi/WifiConfiguration.java
@@ -3395,6 +3395,7 @@ public class WifiConfiguration implements Parcelable {
             // Per-connection MAC randomization doesn't work with some cars, see
             // https://github.com/GrapheneOS/os-issue-tracker/issues/4139
             macRandomizationSetting = RANDOMIZATION_PERSISTENT;
+            mIsSendDhcpHostnameEnabled = true;
         }
     }
 

--- a/framework/java/android/net/wifi/WifiConfiguration.java
+++ b/framework/java/android/net/wifi/WifiConfiguration.java
@@ -3390,6 +3390,12 @@ public class WifiConfiguration implements Parcelable {
         mEncryptedPreSharedKeyIv = new byte[0];
         mIpProvisioningTimedOut = false;
         mVendorData = Collections.emptyList();
+
+        if (android.app.compat.gms.GmsCompat.isAndroidAuto()) {
+            // Per-connection MAC randomization doesn't work with some cars, see
+            // https://github.com/GrapheneOS/os-issue-tracker/issues/4139
+            macRandomizationSetting = RANDOMIZATION_PERSISTENT;
+        }
     }
 
     /**

--- a/framework/java/android/net/wifi/WifiConfiguration.java
+++ b/framework/java/android/net/wifi/WifiConfiguration.java
@@ -1988,7 +1988,7 @@ public class WifiConfiguration implements Parcelable {
         mRandomizedMacAddress = mac;
     }
 
-    private boolean mIsSendDhcpHostnameEnabled = true;
+    private boolean mIsSendDhcpHostnameEnabled;
 
     /**
      * Set whether to send the hostname of the device to this network's DHCP server.

--- a/service/java/com/android/server/wifi/WifiBackupDataV1Parser.java
+++ b/service/java/com/android/server/wifi/WifiBackupDataV1Parser.java
@@ -330,7 +330,6 @@ class WifiBackupDataV1Parser implements WifiBackupDataParser {
         WifiConfiguration configuration = new WifiConfiguration();
         String configKeyInData = null;
         Set<String> supportedTags = getSupportedWifiConfigurationTags(minorVersion);
-        boolean sendDhcpHostnameExists = false;
         // Loop through and parse out all the elements from the stream within this section.
         while (!XmlUtil.isNextSectionEnd(in, outerTagDepth)) {
             String tagName = null;
@@ -427,19 +426,12 @@ class WifiBackupDataV1Parser implements WifiBackupDataParser {
                     break;
                 case WifiConfigurationXmlUtil.XML_TAG_SEND_DHCP_HOSTNAME:
                     configuration.setSendDhcpHostnameEnabled((boolean) value);
-                    sendDhcpHostnameExists = true;
                     break;
                 default:
                     // should never happen, since other tags are filtered out earlier
                     throw new XmlPullParserException(
                             "Unknown value name found: " + tagName);
             }
-        }
-        if (!sendDhcpHostnameExists) {
-            // Update legacy configs to send the DHCP hostname for secure networks only.
-            configuration.setSendDhcpHostnameEnabled(
-                    !configuration.isSecurityType(WifiConfiguration.SECURITY_TYPE_OPEN)
-                    && !configuration.isSecurityType(WifiConfiguration.SECURITY_TYPE_OWE));
         }
         clearAnyKnownIssuesInParsedConfiguration(configuration);
         return Pair.create(configKeyInData, configuration);

--- a/service/java/com/android/server/wifi/WifiConfigManager.java
+++ b/service/java/com/android/server/wifi/WifiConfigManager.java
@@ -1532,12 +1532,13 @@ public class WifiConfigManager {
                 && !mWifiPermissionsUtil.checkConfigOverridePermission(uid)
                 && !(newInternalConfig.isPasspoint() && uid == newInternalConfig.creatorUid)
                 && !config.fromWifiNetworkSuggestion
+                && !mWifiPermissionsUtil.checkWifiPrivilegedAndroidAutoPermission(uid)
                 && !mWifiPermissionsUtil.isDeviceInDemoMode(mContext)
                 && !(mWifiPermissionsUtil.isAdmin(uid, packageName)
                 && uid == newInternalConfig.creatorUid)) {
             Log.e(TAG, "UID " + uid + " does not have permission to modify MAC randomization "
                     + "Settings " + config.getProfileKey() + ". Must have "
-                    + "NETWORK_SETTINGS or NETWORK_SETUP_WIZARD or be in Demo Mode "
+                    + "NETWORK_SETTINGS or NETWORK_SETUP_WIZARD or WIFI_PRIVILEGED_ANDROID_AUTO or be in Demo Mode "
                     + "or be the creator adding or updating a passpoint network "
                     + "or be an admin updating their own network.");
             return new Pair<>(
@@ -1547,10 +1548,11 @@ public class WifiConfigManager {
 
         if (WifiConfigurationUtil.hasSendDhcpHostnameEnabledChanged(existingInternalConfig,
                 newInternalConfig) && !mWifiPermissionsUtil.checkNetworkSettingsPermission(uid)
+                && !mWifiPermissionsUtil.checkWifiPrivilegedAndroidAutoPermission(uid)
                 && !mWifiPermissionsUtil.checkNetworkSetupWizardPermission(uid)) {
             Log.e(TAG, "UID " + uid + " does not have permission to modify send DHCP hostname "
                     + "setting " + config.getProfileKey() + ". Must have "
-                    + "NETWORK_SETTINGS or NETWORK_SETUP_WIZARD.");
+                    + "NETWORK_SETTINGS or NETWORK_SETUP_WIZARD or WIFI_PRIVILEGED_ANDROID_AUTO.");
             return new Pair<>(
                     new NetworkUpdateResult(WifiConfiguration.INVALID_NETWORK_ID),
                     existingInternalConfig);

--- a/service/java/com/android/server/wifi/WifiConfigManager.java
+++ b/service/java/com/android/server/wifi/WifiConfigManager.java
@@ -501,6 +501,10 @@ public class WifiConfigManager {
      * @return
      */
     public boolean shouldUseNonPersistentRandomization(WifiConfiguration config) {
+        if (config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_ALWAYS) {
+            return true;
+        }
+
         if (!isMacRandomizationSupported()
                 || config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_NONE) {
             return false;
@@ -650,7 +654,8 @@ public class WifiConfigManager {
     private MacAddress updateRandomizedMacIfNeeded(WifiConfiguration config) {
         boolean shouldUpdateMac = config.randomizedMacExpirationTimeMs
                 < mClock.getWallClockMillis() || mClock.getWallClockMillis()
-                - config.randomizedMacLastModifiedTimeMs >= NON_PERSISTENT_MAC_REFRESH_MS_MAX;
+                - config.randomizedMacLastModifiedTimeMs >= NON_PERSISTENT_MAC_REFRESH_MS_MAX ||
+                config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_ALWAYS;
         if (!shouldUpdateMac) {
             return config.getRandomizedMacAddress();
         }

--- a/service/java/com/android/server/wifi/WifiConfigurationUtil.java
+++ b/service/java/com/android/server/wifi/WifiConfigurationUtil.java
@@ -287,7 +287,7 @@ public class WifiConfigurationUtil {
     public static boolean hasSendDhcpHostnameEnabledChanged(WifiConfiguration existingConfig,
             WifiConfiguration newConfig) {
         if (existingConfig == null) {
-            return !newConfig.isSendDhcpHostnameEnabled();
+            return newConfig.isSendDhcpHostnameEnabled();
         }
         return newConfig.isSendDhcpHostnameEnabled() != existingConfig.isSendDhcpHostnameEnabled();
     }

--- a/service/java/com/android/server/wifi/WifiConfigurationUtil.java
+++ b/service/java/com/android/server/wifi/WifiConfigurationUtil.java
@@ -271,7 +271,7 @@ public class WifiConfigurationUtil {
     public static boolean hasMacRandomizationSettingsChanged(WifiConfiguration existingConfig,
             WifiConfiguration newConfig) {
         if (existingConfig == null) {
-            return newConfig.macRandomizationSetting != WifiConfiguration.RANDOMIZATION_AUTO;
+            return newConfig.macRandomizationSetting != WifiConfiguration.RANDOMIZATION_ALWAYS;
         }
         return newConfig.macRandomizationSetting != existingConfig.macRandomizationSetting;
     }

--- a/service/java/com/android/server/wifi/WifiServiceImpl.java
+++ b/service/java/com/android/server/wifi/WifiServiceImpl.java
@@ -1054,6 +1054,11 @@ public class WifiServiceImpl extends BaseWifiService {
                 == PackageManager.PERMISSION_GRANTED;
     }
 
+    private boolean checkAndroidAutoPermission(int pid, int uid) {
+        return mContext.checkPermission(android.Manifest.permission.WIFI_PRIVILEGED_ANDROID_AUTO, pid, uid)
+                == PackageManager.PERMISSION_GRANTED;
+    }
+
     private boolean checkMainlineNetworkStackPermission(int pid, int uid) {
         return mContext.checkPermission(NetworkStack.PERMISSION_MAINLINE_NETWORK_STACK, pid, uid)
                 == PackageManager.PERMISSION_GRANTED;
@@ -1254,7 +1259,21 @@ public class WifiServiceImpl extends BaseWifiService {
                 && !isGuestUser())
                 || isPrivileged(pid, uid)
                 || mWifiPermissionsUtil.isAdmin(uid, packageName)
-                || mWifiPermissionsUtil.isSystem(packageName, uid);
+                || mWifiPermissionsUtil.isSystem(packageName, uid)
+                /**
+                 * @see #disconnect
+                 * @see #reconnect
+                 * @see #reassociate
+                 * @see #getConfiguredNetworks
+                 * @see #addOrUpdateNetwork
+                 * @see #removeNetwork
+                 * @see #enableNetwork
+                 * @see #disableNetwork
+                 *
+                 * All of these operations are allowed for unprivileged callers that have
+                 * targetSdk < 29
+                 */
+                || checkAndroidAutoPermission(pid, uid);
     }
 
     private boolean isGuestUser() {
@@ -1318,7 +1337,7 @@ public class WifiServiceImpl extends BaseWifiService {
         }
         int callingUid = Binder.getCallingUid();
         int callingPid = Binder.getCallingPid();
-        boolean isPrivileged = isPrivileged(callingPid, callingUid);
+        boolean isPrivileged = isPrivileged(callingPid, callingUid) || checkAndroidAutoPermission(callingPid, callingUid);
         boolean isThirdParty = !isPrivileged
                 && !isDeviceOrProfileOwner(callingUid, packageName)
                 && !mWifiPermissionsUtil.isSystem(packageName, callingUid);

--- a/service/java/com/android/server/wifi/util/WifiPermissionsUtil.java
+++ b/service/java/com/android/server/wifi/util/WifiPermissionsUtil.java
@@ -833,6 +833,12 @@ public class WifiPermissionsUtil {
                 == PackageManager.PERMISSION_GRANTED;
     }
 
+    public boolean checkWifiPrivilegedAndroidAutoPermission(int uid) {
+        return mWifiPermissionsWrapper.getUidPermission(
+                android.Manifest.permission.WIFI_PRIVILEGED_ANDROID_AUTO, uid)
+                == PackageManager.PERMISSION_GRANTED;
+    }
+
     /**
      * Returns true if the |uid| holds RADIO_SCAN_WITHOUT_LOCATION permission.
      */

--- a/service/java/com/android/server/wifi/util/WifiPermissionsUtil.java
+++ b/service/java/com/android/server/wifi/util/WifiPermissionsUtil.java
@@ -778,6 +778,7 @@ public class WifiPermissionsUtil {
      */
     public boolean isLocationModeEnabled() {
         if (!retrieveLocationManagerIfNecessary()) return false;
+        long ident = Binder.clearCallingIdentity();
         try {
             return mLocationManager.isLocationEnabledForUser(UserHandle.of(
                     mWifiPermissionsWrapper.getCurrentUser()));
@@ -786,6 +787,8 @@ public class WifiPermissionsUtil {
             return mFrameworkFacade.getIntegerSetting(
                     mContext, Settings.Secure.LOCATION_MODE, Settings.Secure.LOCATION_MODE_OFF)
                     == Settings.Secure.LOCATION_MODE_ON;
+        } finally {
+            Binder.restoreCallingIdentity(ident);
         }
     }
 

--- a/service/java/com/android/server/wifi/util/XmlUtil.java
+++ b/service/java/com/android/server/wifi/util/XmlUtil.java
@@ -374,7 +374,14 @@ public class XmlUtil {
         public static final String XML_TAG_ROAMING_CONSORTIUM_OIS = "RoamingConsortiumOIs";
         public static final String XML_TAG_RANDOMIZED_MAC_ADDRESS = "RandomizedMacAddress";
         public static final String XML_TAG_MAC_RANDOMIZATION_SETTING = "MacRandomizationSetting";
-        public static final String XML_TAG_SEND_DHCP_HOSTNAME = "SendDhcpHostname";
+        // SendDhcpHostname setting was added and enabled by default in Android 14 QPR3 for all
+        // saved Wi-Fi networks except for the ones with OPEN or OWE security type.
+        // On 14 QPR3, usage of this setting was disabled with a flag. That flag is enabled starting
+        // with Android 15.
+        // SendDhcpHostname setting is disabled by default for all Wi-Fi networks on GrapheneOS.
+        // It was renamed to SendDhcpHostname2 to ignore the original value for users who upgrade
+        // from 14 QPR3.
+        public static final String XML_TAG_SEND_DHCP_HOSTNAME = "SendDhcpHostname2";
         public static final String XML_TAG_CARRIER_ID = "CarrierId";
         public static final String XML_TAG_SUBSCRIPTION_ID = "SubscriptionId";
         public static final String XML_TAG_IS_AUTO_JOIN = "AutoJoinEnabled";
@@ -875,7 +882,6 @@ public class XmlUtil {
             WifiConfiguration configuration = new WifiConfiguration();
             String configKeyInData = null;
             boolean macRandomizationSettingExists = false;
-            boolean sendDhcpHostnameExists = false;
             byte[] dppConnector = null;
             byte[] dppCSign = null;
             byte[] dppNetAccessKey = null;
@@ -1016,7 +1022,6 @@ public class XmlUtil {
                             break;
                         case XML_TAG_SEND_DHCP_HOSTNAME:
                             configuration.setSendDhcpHostnameEnabled((boolean) value);
-                            sendDhcpHostnameExists = true;
                             break;
                         case XML_TAG_CARRIER_ID:
                             configuration.carrierId = (int) value;
@@ -1152,12 +1157,6 @@ public class XmlUtil {
             if (configuration.macRandomizationSetting
                     == WifiConfiguration.RANDOMIZATION_PERSISTENT && !fromSuggestion) {
                 configuration.macRandomizationSetting = WifiConfiguration.RANDOMIZATION_AUTO;
-            }
-            if (!sendDhcpHostnameExists) {
-                // Update legacy configs to send the DHCP hostname for secure networks only.
-                configuration.setSendDhcpHostnameEnabled(
-                        !configuration.isSecurityType(WifiConfiguration.SECURITY_TYPE_OPEN)
-                        && !configuration.isSecurityType(WifiConfiguration.SECURITY_TYPE_OWE));
             }
             configuration.convertLegacyFieldsToSecurityParamsIfNeeded();
             configuration.setDppConnectionKeys(dppConnector, dppCSign, dppNetAccessKey);


### PR DESCRIPTION
Use cleared calling identity in `isLocationModeEnabled()`