### PR TITLE
fix multi-user handling bug in WifiService package state listener

### DIFF
--- a/service/java/com/android/server/wifi/WifiServiceImpl.java
+++ b/service/java/com/android/server/wifi/WifiServiceImpl.java
@@ -6211,7 +6211,9 @@ public class WifiServiceImpl extends IWifiManager.Stub {
                             return;
                         }
                         String pkgName = uri.getSchemeSpecificPart();
-                        PackageManager pm = context.getPackageManager();
+                        final UserHandle user = UserHandle.of(UserHandle.getUserId(uid));
+                        final Context userContext = context.createContextAsUser(user, 0);
+                        PackageManager pm = userContext.getPackageManager();
                         PackageInfo packageInfo = null;
                         try {
                             packageInfo = pm.getPackageInfo(pkgName, 0);


### PR DESCRIPTION
This bug caused incorrect resets and/or skipped resets of Android Auto Wi-Fi AP association state.

Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/8245