### PR TITLE
2026081301 security patches

### DIFF
--- a/service/java/com/android/server/wifi/WifiNetworkSuggestionsManager.java
+++ b/service/java/com/android/server/wifi/WifiNetworkSuggestionsManager.java
@@ -78,6 +78,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -950,6 +951,11 @@ public class WifiNetworkSuggestionsManager {
         if (!validateCarrierNetworkSuggestions(networkSuggestions, uid, packageName, carrierId)) {
             Log.e(TAG, "bad wifi suggestion from app: " + packageName);
             return WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_ADD_NOT_ALLOWED;
+        }
+        if (SdkLevel.isAtLeastV()) {
+            for (WifiNetworkSuggestion wns : networkSuggestions) {
+                wns.wifiConfiguration.setVendorData(Collections.EMPTY_LIST);
+            }
         }
         for (WifiNetworkSuggestion wns : networkSuggestions) {
             wns.wifiConfiguration.convertLegacyFieldsToSecurityParamsIfNeeded();

--- a/service/java/com/android/server/wifi/WifiServiceImpl.java
+++ b/service/java/com/android/server/wifi/WifiServiceImpl.java
@@ -2237,13 +2237,14 @@ public class WifiServiceImpl extends IWifiManager.Stub {
      */
     @Override
     public boolean validateSoftApConfiguration(SoftApConfiguration config) {
-        int pid = Binder.getCallingPid();
-        int uid = Binder.getCallingUid();
-        boolean privileged = isSettingsOrSuw(pid, uid)
-                || checkNetworkStackPermission(pid, uid)
-                || checkMainlineNetworkStackPermission(pid, uid);
-        return WifiApConfigStore.validateApWifiConfiguration(
-                config, privileged, mContext, mWifiNative);
+        return validateSoftApConfigurationInternal(config, Binder.getCallingUid(),
+                Binder.getCallingPid());
+    }
+
+    private boolean validateSoftApConfigurationInternal(SoftApConfiguration config, int callingUid, int callingPid) {
+        return WifiApConfigStore.validateApWifiConfiguration(config, isSettingsOrSuw(callingPid, callingUid)
+                || checkNetworkStackPermission(callingPid, callingUid)
+                || checkMainlineNetworkStackPermission(callingPid, callingUid), this.mContext, this.mWifiNative);
     }
 
     /**
@@ -2313,7 +2314,7 @@ public class WifiServiceImpl extends IWifiManager.Stub {
         if (!startSoftApInternal(new SoftApModeConfiguration(
                 WifiManager.IFACE_IP_MODE_TETHERED, softApConfig,
                 mTetheredSoftApTracker.getSoftApCapability(),
-                mCountryCode.getCountryCode(), null), requestorWs, null)) {
+                mCountryCode.getCountryCode(), null), requestorWs, null, callingUid, Binder.getCallingPid())) {
             mTetheredSoftApTracker.setFailedWhileEnabling();
             return false;
         }
@@ -2348,7 +2349,7 @@ public class WifiServiceImpl extends IWifiManager.Stub {
         return startTetheredHotspotInternal(new SoftApModeConfiguration(
                 WifiManager.IFACE_IP_MODE_TETHERED, softApConfig,
                 mTetheredSoftApTracker.getSoftApCapability(),
-                mCountryCode.getCountryCode(), null /* request */), callingUid, packageName, null);
+                mCountryCode.getCountryCode(), null /* request */), callingUid, Binder.getCallingPid(), packageName, null);
     }
 
     /**
@@ -2392,7 +2393,7 @@ public class WifiServiceImpl extends IWifiManager.Stub {
                 com.android.net.flags.Flags.tetheringWithSoftApConfig()
                         ? request.getSoftApConfiguration() : null,
                 mTetheredSoftApTracker.getSoftApCapability(),
-                mCountryCode.getCountryCode(), request), callingUid, packageName, callback);
+                mCountryCode.getCountryCode(), request), callingUid, Binder.getCallingPid(), packageName, callback);
     }
 
     private void sendSoftApCallbackStartFailure(@Nullable ISoftApCallback callback,
@@ -2411,7 +2412,7 @@ public class WifiServiceImpl extends IWifiManager.Stub {
      * proper permissions beyond the NetworkStack permission.
      */
     private boolean startTetheredHotspotInternal(@NonNull SoftApModeConfiguration modeConfig,
-            int callingUid, String packageName, @Nullable ISoftApCallback callback) {
+            int callingUid, int callingPid, String packageName, @Nullable ISoftApCallback callback) {
         TetheringManager.TetheringRequest tetheringRequest = modeConfig.getTetheringRequest();
         if (mActiveModeWarden.isSoftApRestartingForCcChange(IFACE_IP_MODE_TETHERED)) {
             mLog.err("Tethering is in the middle of restarting for CC change.").flush();
@@ -2435,12 +2436,12 @@ public class WifiServiceImpl extends IWifiManager.Stub {
             Binder.restoreCallingIdentity(id);
         }
 
-        if (!startSoftApInternal(modeConfig, requestorWs, callback)) {
+        if (!startSoftApInternal(modeConfig, requestorWs, callback, callingUid, callingPid)) {
             mTetheredSoftApTracker.setFailedWhileEnabling();
             return false;
         }
         mLastCallerInfoManager.put(WifiManager.API_TETHERED_HOTSPOT, Process.myTid(),
-                callingUid, Binder.getCallingPid(), packageName, true);
+                callingUid, callingPid, packageName, true);
         return true;
     }
 
@@ -2449,15 +2450,14 @@ public class WifiServiceImpl extends IWifiManager.Stub {
      * proper permissions beyond the NetworkStack permission.
      */
     private boolean startSoftApInternal(SoftApModeConfiguration apConfig, WorkSource requestorWs,
-            @Nullable ISoftApCallback callback) {
-        int uid = Binder.getCallingUid();
-        mLog.trace("startSoftApInternal uid=% mode=%")
-                .c(uid).c(apConfig.getTargetMode()).flush();
+            @Nullable ISoftApCallback callback, int callingUid, int callingPid) {
+        mLog.trace("startSoftApInternal uid=% pid=% mode=%")
+                .c(callingUid).c(callingPid).c(apConfig.getTargetMode()).flush();
 
         // null wifiConfig is a meaningful input for CMD_SET_AP; it means to use the persistent
         // AP config.
         SoftApConfiguration softApConfig = apConfig.getSoftApConfiguration();
-        if (softApConfig != null && !validateSoftApConfiguration(softApConfig)) {
+        if (softApConfig != null && !validateSoftApConfigurationInternal(softApConfig, callingUid, callingPid)) {
             Log.e(TAG, "Invalid SoftApConfiguration");
             if (callback != null) {
                 try {
@@ -3225,8 +3225,10 @@ public class WifiServiceImpl extends IWifiManager.Stub {
             mActiveConfig = new SoftApModeConfiguration(
                     WifiManager.IFACE_IP_MODE_LOCAL_ONLY,
                     softApConfig, lohsCapability, mCountryCode.getCountryCode(), null);
+            WorkSource requestorWs = request.getWorkSource();
+            int startUid = (requestorWs == null || requestorWs.isEmpty()) ? -1 : requestorWs.getUid(0);
             // Report the error if we got failure in startSoftApInternal
-            if (!startSoftApInternal(mActiveConfig, request.getWorkSource(), null)) {
+            if (!startSoftApInternal(mActiveConfig, request.getWorkSource(), null, startUid, request.getPid())) {
                 onStateChanged(new SoftApState(
                         WIFI_AP_STATE_FAILED, SAP_START_FAILURE_GENERAL,
                         mActiveConfig.getTetheringRequest(), null /* iface */));

--- a/service/java/com/android/server/wifi/p2p/WifiP2pServiceImpl.java
+++ b/service/java/com/android/server/wifi/p2p/WifiP2pServiceImpl.java
@@ -1076,6 +1076,7 @@ public class WifiP2pServiceImpl extends IWifiP2pManager.Stub {
         // get the DisplayId of the caller (if available)
         int displayId = Display.DEFAULT_DISPLAY;
         if (mWifiPermissionsUtil.isSystem(packageName, callerUid)) {
+            this.mWifiPermissionsUtil.checkPackage(callerUid, packageName);
             displayId = extras.getInt(WifiP2pManager.EXTRA_PARAM_KEY_DISPLAY_ID,
                     Display.DEFAULT_DISPLAY);
         }
@@ -1210,11 +1211,18 @@ public class WifiP2pServiceImpl extends IWifiP2pManager.Stub {
         if (listener == null) {
             throw new IllegalArgumentException("listener should not be null");
         }
-        mWifiPermissionsUtil.enforceNearbyDevicesPermission(
-                extras.getParcelable(WifiManager.EXTRA_PARAM_KEY_ATTRIBUTION_SOURCE), false,
-                TAG + " registerWifiP2pListener");
+        AttributionSource source = extras != null
+            ? (AttributionSource) extras.getParcelable(WifiManager.EXTRA_PARAM_KEY_ATTRIBUTION_SOURCE, AttributionSource.class)
+            : null;
+        if (source == null) {
+            throw new IllegalArgumentException("AttributionSource should not be null");
+        }
+        if (!source.checkCallingUid()) {
+            throw new SecurityException("AttributionSource UID does not match calling UID");
+        }
+        mWifiPermissionsUtil.enforceNearbyDevicesPermission(source, false, TAG + " registerWifiP2pListener");
         Log.i(TAG, "registerWifiP2pListener uid=" + Binder.getCallingUid());
-        mWifiP2pListeners.register(listener);
+        mWifiP2pListeners.register(listener, source);
     }
 
     /**
@@ -1294,7 +1302,17 @@ public class WifiP2pServiceImpl extends IWifiP2pManager.Stub {
         int numCallbacks = mWifiP2pListeners.beginBroadcast();
         for (int i = 0; i < numCallbacks; i++) {
             try {
-                mWifiP2pListeners.getBroadcastItem(i).onPersistentGroupsChanged(p2pGroupList);
+                AttributionSource source = (AttributionSource) mWifiP2pListeners.getBroadcastCookie(i);
+                if (source == null) {
+                    Log.e("WifiP2pService", "No attribution source for listener, skipping broadcast");
+                    continue;
+                }
+                IWifiP2pListener listener = this.mWifiP2pListeners.getBroadcastItem(i);
+                if (!checkNetworkSettingsOrNetworkStackOrReadWifiCredentialPermission(source.getUid())) {
+                    listener.onPersistentGroupsChanged(new WifiP2pGroupList());
+                } else {
+                    listener.onPersistentGroupsChanged(this.mP2pStateMachine.maybeEraseOwnDeviceAddress(p2pGroupList, source.getUid()));
+                }
             } catch (RemoteException e) {
                 Log.e(TAG, "Failure calling onPersistentGroupsChanged" + e);
             }
@@ -6274,7 +6292,8 @@ public class WifiP2pServiceImpl extends IWifiP2pManager.Stub {
         private boolean checkNearbyDevicesPermission(int uid, String packageName, Bundle extras,
                 String message, Object attributionSource) {
             if (extras != null
-                    && extras.getBoolean(WifiP2pManager.EXTRA_PARAM_KEY_INTERNAL_MESSAGE)) {
+                    && extras.getBoolean(WifiP2pManager.EXTRA_PARAM_KEY_INTERNAL_MESSAGE)
+                    && uid == Process.myUid()) {
                 // bypass permission check for internal call.
                 return true;
             }

--- a/service/java/com/android/server/wifi/scanner/WifiScanningServiceImpl.java
+++ b/service/java/com/android/server/wifi/scanner/WifiScanningServiceImpl.java
@@ -1486,6 +1486,12 @@ public class WifiScanningServiceImpl extends IWifiScanner.Stub {
                             + " does not have permission to set type");
                     return false;
                 }
+                if (SdkLevel.isAtLeastC()
+                        && !settings.getVendorIes().isEmpty()
+                        && Process.isPrivateComputeCoreUid(ci.getUid())) {
+                    Log.e(TAG, "Failing single scan because app " + ci.getUid() + " does not have permission to set vendor IEs");
+                    return false;
+                }
             }
             return true;
         }

--- a/service/java/com/android/server/wifi/util/WifiPermissionsUtil.java
+++ b/service/java/com/android/server/wifi/util/WifiPermissionsUtil.java
@@ -1165,6 +1165,10 @@ public class WifiPermissionsUtil {
             if (SdkLevel.isAtLeastT() && Process.isSdkSandboxUid(uid)) {
                 return false;
             }
+            if (SdkLevel.isAtLeastC() && Process.isPrivateComputeCoreUid(uid)) {
+                Log.w(TAG, "isSystem: isPrivateComputeCoreUid, returning false");
+                return false;
+            }
             ApplicationInfo info = mContext.getPackageManager().getApplicationInfoAsUser(
                     packageName, 0, UserHandle.getUserHandleForUid(uid));
             return (info.flags & APP_INFO_FLAGS_SYSTEM_APP) != 0;


### PR DESCRIPTION
I ported the security patches from decompiled diff of 2026081300..2026081301.

Smali diff (my local build vs 2026081301):
```diff
diff -ruN -I '^\.source ' a/com/android/server/wifi/WifiServiceImpl$LohsSoftApTracker.smali b/com/android/server/wifi/WifiServiceImpl$LohsSoftApTracker.smali
--- a/com/android/server/wifi/WifiServiceImpl$LohsSoftApTracker.smali	1970-01-01 03:00:00.000000000 +0300
+++ b/com/android/server/wifi/WifiServiceImpl$LohsSoftApTracker.smali	1970-01-01 03:00:00.000000000 +0300
@@ -708,33 +708,33 @@
 
     move-result-object v0
 
-    if-eqz v0, :cond_95
+    if-eqz v0, :cond_94
 
     invoke-virtual {v0}, Landroid/os/WorkSource;->isEmpty()Z
 
     move-result v1
 
-    if-eqz v1, :cond_8f
+    if-nez v1, :cond_94
 
-    goto :goto_95
-
-    :cond_8f
     invoke-virtual {v0, v3}, Landroid/os/WorkSource;->getUid(I)I
 
     move-result v0
 
-    :goto_93
+    :goto_92
     move v8, v0
 
-    goto :goto_97
+    goto :goto_96
 
-    :cond_95
-    :goto_95
+    :cond_94
     const/4 v0, -0x1
 
-    goto :goto_93
+    goto :goto_92
+
+    :goto_96
+    invoke-virtual {p1}, Lcom/android/server/wifi/LocalOnlyHotspotRequestInfo;->getPid()I
+
+    move-result v9
 
-    :goto_97
     iget-object v4, p0, Lcom/android/server/wifi/WifiServiceImpl$LohsSoftApTracker;->this$0:Lcom/android/server/wifi/WifiServiceImpl;
 
     iget-object v5, p0, Lcom/android/server/wifi/WifiServiceImpl$LohsSoftApTracker;->mActiveConfig:Lcom/android/server/wifi/SoftApModeConfiguration;
@@ -745,15 +745,11 @@
 
     const/4 v7, 0x0
 
-    invoke-virtual {p1}, Lcom/android/server/wifi/LocalOnlyHotspotRequestInfo;->getPid()I
-
-    move-result v9
-
     invoke-static/range {v4 .. v9}, Lcom/android/server/wifi/WifiServiceImpl;->-$$Nest$mstartSoftApInternal(Lcom/android/server/wifi/WifiServiceImpl;Lcom/android/server/wifi/SoftApModeConfiguration;Landroid/os/WorkSource;Landroid/net/wifi/ISoftApCallback;II)Z
 
     move-result p1
 
-    if-nez p1, :cond_bb
+    if-nez p1, :cond_ba
 
     new-instance p1, Landroid/net/wifi/SoftApState;
 
@@ -771,7 +767,7 @@
 
     invoke-virtual {p0, p1}, Lcom/android/server/wifi/WifiServiceImpl$LohsSoftApTracker;->onStateChanged(Landroid/net/wifi/SoftApState;)V
 
-    :cond_bb
+    :cond_ba
     return-void
 .end method
```

Functionally identical, but not exactly the same. I can try to get the bytecode to be exact if needed.